### PR TITLE
Fixed division to yield integer type

### DIFF
--- a/pyfilterbank/butterworth.py
+++ b/pyfilterbank/butterworth.py
@@ -83,7 +83,7 @@ def butter_analog_sos(band, L, w1, w2=0):
 
     """
     band = band.lower()
-    L2 = L / 2.0
+    L2 = L // 2
     if mod(L, 2):
         raise Exception('Number of poles L must be even')
     if w1 <= 0:

--- a/pyfilterbank/octbank.py
+++ b/pyfilterbank/octbank.py
@@ -501,7 +501,7 @@ def freqz(ofb, length_sec=6, ffilt=False, plot=True):
     """
     from pylab import np, plt, fft, fftfreq
     x = np.zeros(length_sec*ofb.sample_rate)
-    x[length_sec*ofb.sample_rate/2] = 0.9999
+    x[length_sec*ofb.sample_rate//2] = 0.9999
     if not ffilt:
         y, states = ofb.filter_mimo_c(x)
         y = y[:, :, 0]
@@ -516,8 +516,8 @@ def freqz(ofb, length_sec=6, ffilt=False, plot=True):
             fig = plt.figure('freqz filter bank')
             plt.grid(True)
             plt.axis([0, ofb.sample_rate / 2, -100, 5])
-            L = 20*np.log10(np.abs(X[:len(x)/2]) + 1e-17)
-            plt.semilogx(f[:len(x)/2], L, lw=0.5)
+            L = 20*np.log10(np.abs(X[:len(x)//2]) + 1e-17)
+            plt.semilogx(f[:len(x)//2], L, lw=0.5)
             plt.hold(True)
 
     Y = fft(s)
@@ -530,8 +530,8 @@ def freqz(ofb, length_sec=6, ffilt=False, plot=True):
 
 
         plt.figure('sum')
-        L = 20*np.log10(np.abs(Y[:len(x)/2]) + 1e-17)
-        plt.semilogx(f[:len(x)/2], L, lw=0.5)
+        L = 20*np.log10(np.abs(Y[:len(x)//2]) + 1e-17)
+        plt.semilogx(f[:len(x)//2], L, lw=0.5)
         level_input = 10*np.log10(np.sum(x**2))
         level_output = 10*np.log10(np.sum(s**2))
         plt.axis([5, ofb.sample_rate/1.8, -50, 5])

--- a/pyfilterbank/octbank.py
+++ b/pyfilterbank/octbank.py
@@ -518,7 +518,6 @@ def freqz(ofb, length_sec=6, ffilt=False, plot=True):
             plt.axis([0, ofb.sample_rate / 2, -100, 5])
             L = 20*np.log10(np.abs(X[:len(x)//2]) + 1e-17)
             plt.semilogx(f[:len(x)//2], L, lw=0.5)
-            plt.hold(True)
 
     Y = fft(s)
     if plot:
@@ -526,8 +525,6 @@ def freqz(ofb, length_sec=6, ffilt=False, plot=True):
         plt.xlabel('Frequency / Hz')
         plt.ylabel(u'Damping /dB(FS)')
         plt.xlim((10, ofb.sample_rate/2))
-        plt.hold(False)
-
 
         plt.figure('sum')
         L = 20*np.log10(np.abs(Y[:len(x)//2]) + 1e-17)


### PR DESCRIPTION
In the function `butter_analog_sos` the line `d = zeros((L2, 2), dtype=double).astype(complex)` has thrown an error in numpy 1.13.3 since the datatype of `L2` was `float`.