### PR TITLE
Fixed some lines that made it not work with python 3

### DIFF
--- a/pyfilterbank/gammatone.py
+++ b/pyfilterbank/gammatone.py
@@ -338,7 +338,7 @@ class GammatoneFilterbank:
 
     def estimate_max_indices_and_slopes(self, delay_samples=None):
         if not delay_samples:
-            delay_samples = self.samplerate/10
+            delay_samples = int(self.samplerate/10)
         sig = _create_impulse(delay_samples)
         bands = list(zip(*self.analyze(sig)))[0]
         ibandmax = [np.argmax(np.abs(b[:delay_samples])) for b in bands]

--- a/pyfilterbank/gammatone.py
+++ b/pyfilterbank/gammatone.py
@@ -382,7 +382,6 @@ def example_filterbank():
 
     def plotfun(x, y):
         ax.semilogx(x, 20*np.log10(np.abs(y)**2))
-        plt.hold(True)
 
     gfb.freqz(nfft=2*4096, plotfun=plotfun)
     plt.grid(True)


### PR DESCRIPTION
Two things fixed:

a) `gammatone.py` had fractional `delay_samples` value when called form within python 3 (since division returns float)
b) removed `matplotlib.hold` from `plotfunc` since this function has been deprecated (default is always `True`)